### PR TITLE
CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -57,7 +57,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
       - uses: julia-actions/cache@v2
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Bump actions/checkout from 5 to 6

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)