### PR TITLE
Fix &nbsp entities missing semicolons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ YYJSON is a convenient wrapper around [yyjson](https://github.com/ibireme/yyjson
 <html>
   <body>
     <table>
-      <tr><th>Feature&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp</th><th><div>Description</div></th></tr>
+      <tr><th>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th><th><div>Description</div></th></tr>
       <tr>
         <td>Performance</td>
         <td><div>Able to <code>read</code> gigabytes of JSON document per second.</div></td>


### PR DESCRIPTION
## Summary
- Fix 8 `&nbsp` HTML entities that were missing their trailing semicolons in the HTML table header
- Changed `&nbsp` to `&nbsp;` for valid HTML entity syntax